### PR TITLE
fix: omit description if undefined

### DIFF
--- a/src/runtime/server/routes/llms.txt.get.ts
+++ b/src/runtime/server/routes/llms.txt.get.ts
@@ -27,7 +27,9 @@ export default eventHandler(async (event) => {
     }
     document.push(
       section.links?.map((link) => {
-        return `- [${link.title}](${link.href}): ${link.description}`
+        return link.description
+          ? `- [${link.title}](${link.href}): ${link.description}`
+          : `- [${link.title}](${link.href})`
       }).join('\n') || '',
     )
   }


### PR DESCRIPTION
According to https://llmstxt.org/, the `description` field for a link is optional. Therefore, if `link.description` is undefined, it can be omitted.
