### PR TITLE
fix: link leads to a 404 page

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ export default defineNuxtConfig({
 })
 ```
 
-Checkout the [Nuxt Content documentation](https://content.nuxt.com/docs/usage/content-pages) for more information on how to write your content files.
+Checkout the [Nuxt Content documentation](https://content.nuxt.com/docs/files/markdown) for more information on how to write your content files.
 
 And checkout the [Nuxt Content llms documentation](https://content.nuxt.com/docs/advanced/llms) for more information on how to customize LLMs contents with `nuxt-llms` and `@nuxt/content`.
 


### PR DESCRIPTION
The https://content.nuxt.com/docs/usage/content-pages was leading to a 404 page, so I replaced it with https://content.nuxt.com/docs/files/markdown, but I'm not entirely sure about this.