### PR TITLE
chore: fix formatting in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>nuxt/renovate-config-nuxt",
+    "github>nuxt/renovate-config-nuxt"
   ]
 }


### PR DESCRIPTION
This pull request contains a minor formatting change to the `renovate.json` configuration file. There are no functional changes, only the removal of an unnecessary trailing comma.

Closes #21