### PR TITLE
[ci skip] docs: fix Nuxt badge icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,5 +269,5 @@ Copyright (c) NuxtLabs
 [license-src]: https://img.shields.io/npm/l/nuxt-llms.svg?style=flat&colorA=020420&colorB=00DC82
 [license-href]: https://npmjs.com/package/nuxt-llms
 
-[nuxt-src]: https://img.shields.io/badge/Nuxt-020420?logo=nuxt.js
+[nuxt-src]: https://img.shields.io/badge/Nuxt-020420?logo=nuxt
 [nuxt-href]: https://nuxt.com


### PR DESCRIPTION
The Nuxt logo is missing from Nuxt badge in the README.md.

[![Nuxt][_nuxt-src]][_nuxt-href] `->` [![Nuxt][nuxt-src]][nuxt-href]

See [original issue](https://github.com/nuxt/starter/issues/1659) from the module template for more details.

[_nuxt-src]: https://img.shields.io/badge/Nuxt-020420?logo=nuxt.js
[_nuxt-href]: https://nuxt.com
[nuxt-src]: https://img.shields.io/badge/Nuxt-020420?logo=nuxt
[nuxt-href]: https://nuxt.com

https://github.com/nuxt/starter/issues/1659