### PR TITLE
chore: migrate to pnpm 11 and use allowBuilds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - run: npm i -g --force corepack && corepack enable
       - name: Install dependencies

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-shamefully-hoist=true
-strict-peer-dependencies=false

--- a/package.json
+++ b/package.json
@@ -72,5 +72,5 @@
       "releaseName": "v${version}"
     }
   },
-  "packageManager": "pnpm@10.28.0"
+  "packageManager": "pnpm@11.3.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+shamefullyHoist: true
+strictPeerDependencies: false
+
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  unrs-resolver: true


### PR DESCRIPTION
Migrate to pnpm 11 and use allowBuilds. Settings move from `.npmrc` to `pnpm-workspace.yaml` since pnpm 11 only reads auth/registry from `.npmrc`.